### PR TITLE
open opps doesn't want to include projects at launch

### DIFF
--- a/assets/js/backbone/config/ui.json
+++ b/assets/js/backbone/config/ui.json
@@ -1,5 +1,11 @@
 {
   "project": {
-    "show": true
+    "show": false
+  },
+  "supervisorEmail": {
+	  "useSupervisorEmail": false
+  },
+  "home": {
+    "logged_in_path": "/tasks"
   }
 }


### PR DESCRIPTION
fixes #12 and #13 
also we want supervisor email setting off (was added in last release)
