### PR TITLE
Updating GA code with midas-specific one.

### DIFF
--- a/config/settings/analytics.js
+++ b/config/settings/analytics.js
@@ -3,7 +3,7 @@ module.exports = {
   //ANALYTICS SETTINGS
   google: {
     enabled: true,
-    key: 'UA-48605964-16'
+    key: 'UA-48605964-17'
   },
   piwik: {
     enabled: false,


### PR DESCRIPTION
The previous Google Analytics code was not specific to Midas.

Related to #27.
