### PR TITLE
Added DAP configuration option values.

### DIFF
--- a/config/settings/analytics.js
+++ b/config/settings/analytics.js
@@ -9,5 +9,9 @@ module.exports = {
     enabled: false,
     host: '',
     key: ''
+  },
+  dap: {
+    enabled: true,
+    source: 'https://dvs6mwdoj87wa.cloudfront.net/dap.min.js'
   }
 };


### PR DESCRIPTION
This requires 18F/midas#455 to function, which makes DAP
configurable on a instance-by-instance basis. The dap script
is a cdn hosted 18f version of the file.

Addresses #27
