### PR TITLE
Fix typo in Open Opps callout

### DIFF
--- a/assets/js/backbone/apps/home/templates/home_view_template.html
+++ b/assets/js/backbone/apps/home/templates/home_view_template.html
@@ -53,7 +53,7 @@
   </div>
   <div class="container-fluid padding-left-none padding-right-none final-call">
     <div class="text-center col-md-8 col-md-offset-2">
-      <p class="title">Find Open Opportunities that match your skills or let you explore new horizons while make an impact across government.</p>
+      <p class="title">Find Open Opportunities that match your skills or let you explore new horizons while making an impact across government.</p>
       <a class="login" href="/auth">
         <button class="btn btn-midas" id="center">Discover More</button>
       </a>


### PR DESCRIPTION
This fixes the grammar typo that appears on the homepage of https://openopps.digitalgov.gov -

![screenshot from 2015-08-11 22-46-53](https://cloud.githubusercontent.com/assets/4592/9215631/0860c052-407b-11e5-8e5f-f6ec57467a24.png)

To be "...making an impact across government".