### PR TITLE
Headline change to open opportunities

### DIFF
--- a/assets/js/backbone/apps/home/templates/home_view_template.html
+++ b/assets/js/backbone/apps/home/templates/home_view_template.html
@@ -1,7 +1,7 @@
   <div class="container-fluid padding-left-none padding-right-none">
     <div class="splash-wrap" id="splash1">
       <div class="splash-center">
-      <h1 class="text-center" data-i18n="home.headline">Hassle Free Collaboration</h1>
+      <h1 class="text-center" data-i18n="home.headline">Open Opportunities</h1>
       <p class="lead text-center" data-i18n="home.subhead">Work with other federal employees on projects you are passionate about.</p>
       <hr/>
       <p class="tagline text-center" data-i18n="home.tagline">Building a 21st century government, together</p>


### PR DESCRIPTION
We're changing the headline from 'Hassle-free' to 'Open Opportunities' in 18F/midas#951 and this is to make sure everything is the same so we don't get bitten by theming... again.

Just because this is an out of the way repo, pinging @dhcole for a review/merge.