### PR TITLE
Update to new DAP location

### DIFF
--- a/config/settings/analytics.js
+++ b/config/settings/analytics.js
@@ -12,6 +12,6 @@ module.exports = {
   },
   dap: {
     enabled: true,
-    source: 'https://analytics.usa.gov/dap/dap.min.js'
+    source: 'https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA'
   }
 };


### PR DESCRIPTION
This changes the DAP embed code to:

```
<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
```

This takes advantage of the DAP's new [centrally hosted JavaScript code](https://www.digitalgov.gov/2015/08/14/secure-central-hosting-for-the-digital-analytics-program/), which means 18f.gsa.gov will automatically get security updates, new features, and other bugfixes automatically.